### PR TITLE
feat: #2 3の倍数を除外した合計計算機能

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -13,18 +13,23 @@ namespace ConsoleApp2
             Console.OutputEncoding = System.Text.Encoding.UTF8;
             Console.InputEncoding = System.Text.Encoding.UTF8;
             
-            Console.WriteLine("=== Issue #1: 1から100までの合計計算 ===");
+            Console.WriteLine("=== Issue #2: 1から100まで（3の倍数除外）の合計計算 ===");
             
             int sum = 0;
             for (int i = 1; i <= 100; i++)
             {
-                Console.WriteLine($"[DEBUG] 現在の値: {i}, 累計: {sum + i}");
+                if (i % 3 == 0)
+                {
+                    Console.WriteLine($"[DEBUG] {i}は3の倍数のためスキップ");
+                    continue;
+                }
+                Console.WriteLine($"[DEBUG] 加算: {i}, 累計: {sum + i}");
                 sum += i;
             }
             
-            Console.WriteLine($"\n結果: 1から100までの合計 = {sum}");
-            Console.WriteLine("期待値: 5050");
-            Console.WriteLine($"計算確認: {(sum == 5050 ? "✅ 正確" : "❌ エラー")}");
+            Console.WriteLine($"\n結果: 1から100まで（3の倍数除外）の合計 = {sum}");
+            Console.WriteLine("期待値: 3367");
+            Console.WriteLine($"計算確認: {(sum == 3367 ? "✅ 正確" : "❌ エラー")}");
         }
     }
 }


### PR DESCRIPTION
## 概要
Issue #2 の実装です。1から100までの数値で3の倍数を除外して合計する機能を追加しました。

## 実装内容
- 3で割り切れる数をスキップ（3, 6, 9, 12, 15, 18, 21, 24, 27, 30...99）
- continue文によるスキップ処理
- 合計結果: **3367**
- デバッグ出力でスキップ・加算処理を詳細表示

## テスト結果
- ✅ 期待値 3367 と一致
- ✅ 3の倍数が正しくスキップされることを確認
- ✅ デバッグ出力で各ステップ確認済み

## 関連Issue
Closes #2